### PR TITLE
Native EPGM writer

### DIFF
--- a/src/stellar_ingest/datasrc.clj
+++ b/src/stellar_ingest/datasrc.clj
@@ -1,0 +1,94 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; This file is part of stellar-ingest, Stellar data ingestion module.
+;;
+;; Copyright 2017-2018 CSIRO Data61
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License"); you may not
+;; use this file except in compliance with the License.  You may obtain a copy
+;; of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless  required  by applicable  law  or  agreed  to in  writing,  software
+;; distributed under the  License is distributed on an "AS  IS" BASIS, WITHOUT
+;; WARRANTIES OR CONDITIONS  OF ANY KIND, either express or  implied.  See the
+;; License  for the  specific language  governing permissions  and limitations
+;; under the License.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(ns stellar-ingest.datasrc
+  ;; TODO: check if any is unnecessary.
+  (:require [stellar-ingest.core :as core]
+            [stellar-ingest.utils :as utils]
+            ;; Logging
+            [clojure.tools.logging :as log]
+            ;; I/O.
+            [clojure.data.csv :as csv]
+            [clojure.java.io :as io]
+            ;; String manipulation
+            [clojure.string]
+            ;; Category theory types.
+            [cats.core :as cats]
+            [cats.monad.either :as either]
+            [cats.context :as ctx]
+            ;; Cheshire JSON library
+            [cheshire.core :as json]
+            ;; Memory meter
+            [clj-memory-meter.core :as mm])
+  (:gen-class))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+
+;; Unused.
+;; (defn load-csv "" [file]
+;;   (core/csv-data->maps (core/file-line-parse-seq file (comp first csv/read-csv))))
+
+;; In the future  there should be a unique function  that accepts multiple types
+;; of data source (CSV, DB, etc.) and creates node/links.
+;;
+;; (defn data-source-to-seq
+;;   "Given a data source specification and  a conversion function, return a sequence
+;;   of node/link maps, as internally used by the ingestor."
+;;   ;; For backward compatibility if a string  is passed, it is interpreted as CSV
+;;   ;; path with default parameters. For CSVs a source specification map will also
+;;   ;; be included, that allows parameters (e.g. headers yes/no, separator, ...).
+;;   [src  ;; The data source specification (map or string).
+;;    fun] ;; The function converting from data elements to nodes/edges.
+;;   (if (string? src)
+;;     (map fun src)
+;;     (throw (Exception. (str "Map datasources aren't yet supported.")))))
+
+;; Line-by-line file reader implemented as a reducible sequence.
+(defn- lines-reducible [^java.io.BufferedReader rdr]
+  (reify clojure.lang.IReduceInit
+    (reduce [this f init]
+      (try
+        (loop [state init]
+          (if (reduced? state)
+            state
+            (if-let [line (.readLine rdr)]
+              (recur (f state line))
+              state)))
+        (finally (.close rdr))))))
+
+;; Eduction presenting a parsed CSV file, i.e. a sequence of records.
+(defn parse-csv-file-reducible [file]
+  (eduction (map (comp first csv/read-csv))
+            (lines-reducible (io/reader file))))
+
+;; Parse JSON lines.
+;; (defn parse-json-file-reducible [file]
+;;   (eduction (map #(json/decode % true))
+;;             (lines-reducible (io/reader file))))
+
+;; Stateful transducer that performs the CSV record to map transformation.
+(defn csv-data->maps-trans []
+  (fn [rf]
+    (let [cols (atom nil)]
+      (fn
+        ([] (rf))
+        ([res] (rf res))
+        ([res inp] (if (nil? @cols)
+                     (do (reset! cols (into [] (map keyword inp))) res)
+                     (rf res (zipmap @cols inp))))))))

--- a/src/stellar_ingest/rest.clj
+++ b/src/stellar_ingest/rest.clj
@@ -102,14 +102,16 @@
 (defn- ingestion-ok [url sid]
   (log/info (str "Sending OK to " url))
   (try (http/post url
-                  {:body (str "{\"sessionId\":\"" sid "\"}")})
+                  {:body (str "{\"sessionId\":\"" sid "\"}")
+                   :content-type "application/json"})
     (catch Exception e (log/info (.getMessage e)))))
 
 (defn- ingestion-abort [url sid reason]
   (log/info (str "Sending Error to " url))
   (try (http/post url
                   {:body (str "{\"sessionId\":\"" sid "\", "
-                              "\"reason\":\"" reason "\"}")})
+                              "\"reason\":\"" reason "\"}")
+                   :content-type "application/json"})
   (catch Exception e (log/info (.getMessage e)))))
 
 ;; Ingestion procedure.

--- a/src/stellar_ingest/schema.clj
+++ b/src/stellar_ingest/schema.clj
@@ -1,7 +1,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; This file is part of stellar-ingest, Stellar data ingestion module.
 ;;
-;; Copyright 2017 CSIRO Data61
+;; Copyright 2017-2018 CSIRO Data61
 ;;
 ;; Licensed under the Apache License, Version 2.0 (the "License"); you may not
 ;; use this file except in compliance with the License.  You may obtain a copy
@@ -18,9 +18,13 @@
 
 (ns stellar-ingest.schema
   ;; TODO: check if any is unnecessary.
+  ;; TODO:  this  namespace  has  grown  to  include  too  many  things  (schema
+  ;; management,   creation   of   intermediate  representations,   writing   of
+  ;; output). Divide functions by topic and assign to new namespaces.
   (:require [stellar-ingest.core :as core]
             [stellar-ingest.utils :as utils]
             [stellar-ingest.schema-validator :as vtor]
+            [stellar-ingest.datasrc :as dsrc]
             ;; Logging
             [clojure.tools.logging :as log]
             ;; I/O.
@@ -35,7 +39,9 @@
             ;; Cheshire JSON library
             [cheshire.core :as json]
             ;; Memory meter
-            [clj-memory-meter.core :as mm])
+            [clj-memory-meter.core :as mm]
+            ;; Used to test functions as parameters
+            [clojure.test :refer [function?]])
   (:import
    (sh.serene.stellarutils.entities Properties)
    (sh.serene.stellarutils.graph.api StellarBackEndFactory StellarGraph StellarGraphBuffer)
@@ -43,7 +49,7 @@
   (:gen-class))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
+;; Functions to deal with the schema and to convert input data using it.
 
 (defn load-schema
   ""
@@ -58,9 +64,6 @@
    (clojure.java.io/writer file)
    {:key-fn (fn [k] (clojure.string/replace (name k) #"^stellar-" "@"))
     :pretty true}))
-
-(defn load-csv "" [file]
-  (core/csv-data->maps (core/file-line-parse-seq file (comp first csv/read-csv))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Given a schema map  and a source return a copy of  the schema containing only
@@ -161,7 +164,9 @@
    l] ;; A line of data
   (let [;; Extract node mappings from the schema
         ms (-> s :mapping :nodes)]
-  (for [m ms] (apply-node-mapping m l))))
+    (for [m ms] (apply-node-mapping m l))
+    ;; (into {} l)
+    ))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -242,7 +247,14 @@
          ;; If  empty mappings, skip processing input file.
          (if (empty? (-> scm :mapping :nodes))
            (lazy-seq)
-           (map (partial apply-all-node-mappings scm) dat))))
+           ;; DB: here the data source must be hooked. Ideally, to maintain good
+           ;; encapsulation there should be a source-to sequence function called
+           ;; that  receives the  apply-... function  and runs  it. This  way we
+           ;; don't have to put with-open etc. in this namespace.
+           ;;
+           (map (partial apply-all-node-mappings scm) dat)
+
+           )))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -256,14 +268,18 @@
          ;; If  empty mappings, skip processing input file.
          (if (empty? (-> scm :mapping :links))
            (lazy-seq)
-           (map (partial apply-all-link-mappings scm) dat))))
+           (map (partial apply-all-link-mappings scm) dat)
+           )))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Helper  functions to  populate  the  graph. The  final  graph  consists of  a
-;; StellarGraphBuffer object. The  ingestor transforms the input  data into lazy
-;; sequences of intermediate objects (maps)  that represent the nodes and edges,
-;; as defined in the schema.
+;; Graph  construction backends  convert Ingestor's  intermediate representation
+;; into a graph object suitable for encoding into EPGM. The '-utils' one creates
+;; a StellarGraphBuffer  object and is about  to be deprecated in  favour of the
+;; native one.  A  dispatch function 'populate-graph', defaulting  to native, is
+;; provided  to  hide   the  implementation  and  make   source  code  backwards
+;; compatible.
 
+;; Helper function to populate nodes of the stellar-utils graph backend.
 (defn- populate-graph-nodes-fn [graph]
   (fn [v]
     (let [label (:label v)
@@ -272,16 +288,11 @@
           oldid (:__id propm)
           newid (str label oldid)
           n (:stellar-count v)]
-      (try
-        ;; A log line every 250k seems good...
-        (if (= 0 (mod n 250000))
-          (log/info (str (new java.util.Date) " - ingested " n " graph nodes.")))
-        ;; (println (str "Node: " v))
-        (.addVertex graph newid label propj)
-        (catch Exception e
-          (str "caught exception: " (.getMessage e)))
-        (finally nil)))))
+      (try (.addVertex graph newid label propj)
+           (catch Exception e
+             (log/error (str "Error adding node: " (.getMessage e))) nil)))))
 
+;; Helper function to populate links of the stellar-utils graph backend.
 (defn- populate-graph-links-fn [graph]
   (fn [e]
     (let [label (:label e)
@@ -293,54 +304,137 @@
           dst-orig (str (:dst-label e) (:dst-val e))
           n (:stellar-count e)]
       (try
-        ;; A log line every 250k seems good...
-        (if (= 0 (mod n 250000))
-          (log/info (str (new java.util.Date) " - ingested " n " graph links.")))
-        ;; (println (str "Link: " e))
         (.addEdge graph newid src-orig dst-orig label (.getMap (Properties/create)))
         (catch Exception ex
-          (println (str "caught exception: " (.getMessage ex))))
-        (finally nil)
-        ))))
+          (log/error (str "Error adding link: " (.getMessage ex))) nil)))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-(defn populate-graph
+;; Graph backend  using stellar-utils:  deprecated, because  the utils  load the
+;; entire graph in memory.
+(defn populate-graph-utils
   "This function  marks the  limit between the  the ingestor's  native clojure
   code and the  stellar.util java library.  Maps representing  nodes and links
   are  converted  to  the  corresponding   util  object  and  collected  in  a
   GraphCollectionBuilder object, from which the distributed graph is created."
+  ;; TODO: this  function expects  lazy sequences as  input and  stopped working
+  ;; when  stellar-ingest  switched to  using  transducers  internally. Must  be
+  ;; converted to keep on working for backward compatibility.
   [vs  ;; Maps of vertices
    es  ;; Maps of edges
    gl] ;; Graph label
+  (log/info "Entering function populate-graph-utils.")
   (let [;; Select graph memory backend: local memory.
         grbef (new LocalBackEndFactory)
         ;; Create and empty graph, that will be populated element-wise.
         graph (.createGraph grbef gl (.getMap (Properties/create)))]
-
+    
     ;; Process all nodes.
     (log/info (str (new java.util.Date) " - Starting node ingestion."))
-    (dorun (map (populate-graph-nodes-fn graph) (vs)))
-    (log/info (str (new java.util.Date)
-                   " - Finished ingesting "
-                   (:stellar-count (last (vs)))
-                   " graph nodes."))
-
+    (dorun (sequence (comp (map (populate-graph-nodes-fn graph))
+                           (utils/element-log-tran #(log/info %) 250000 "nodes"))
+                     vs))
+    (log/info (str (new java.util.Date) " - Completed node ingestion."))
+    
     ;; Process all links.
     (log/info (str (new java.util.Date) " - Starting link ingestion."))
-    (dorun (map (populate-graph-links-fn graph) (es)))
-    (log/info (str (new java.util.Date)
-                   " - Finished ingesting "
-                   (:stellar-count (last (es)))
-                   " graph links."))
+    (dorun (sequence (comp (map (populate-graph-links-fn graph))
+                           (utils/element-log-tran #(log/info %) 250000 "links"))
+                     es))
+    (log/info (str (new java.util.Date) " - Completed link ingestion."))
 
     ;; Return the graph.
+    (log/info "Leaving function populate-graph-utils.")
     graph))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Graph  construction backends  convert Ingestor's  intermediate representation
+;; into  a graph  object  suitable for  encoding into  EPGM.   The native  graph
+;; construction backend returns a map with sequences of graphs, nodes and links.
+;; The three sequences  are actually eductions that will  perform data ingestion
+;; upon reduction.
 ;;
+;; Utility: add graph ID to a node/link, that a :graphs key pointing to a vector
+;; of graph IDs.
+(defn- add-graph-id
+  [id x]
+  (assoc x :graphs [id]))
 
-(defn write-graph-to-gdf
+;; Utility: convert internal node representation to EPGM-compatible.
+;; Assumes :graphs key points to a vector of graph IDs.
+(defn- node-map-to-epgm [n]
+  (let [label  (:label n)
+        graphs (:graphs n)
+        propm  (:props n)
+        oldid  (:__id propm)
+        newid  (str label oldid)]
+    {:id newid
+     :meta {:label label :graphs graphs}
+     :data propm}))
+
+;; Utility: convert internal link representation to EPGM-compatible.
+;; Assumes :graphs key points to a vector of graph IDs.
+(defn- link-map-to-epgm [e]
+  (let [label (:label e)
+        graphs (:graphs e)
+        propm (:props e)
+        oldid (:__id propm)
+        newid (str label oldid)
+        newsrc (str (:src-label e) (:src-val e))
+        newdst (str (:dst-label e) (:dst-val e))]
+    {:id newid
+     :source newsrc
+     :target newdst
+     :meta {:label label :graphs graphs}
+     :data propm}))
+
+;; Actual native graph builder function.
+(defn populate-graph-native
+  "
+  Build  stellar-ingest  internal  graph  object,  a  hashmap  containing  three
+  sequences (graphs, nodes and links) suitable for representation as EPGM.
+  "
+  [vs  ;; Eduction generating vertices
+   es  ;; Eduction generating edges
+   gl] ;; Graph label
+  (log/info "Entering function populate-graph-native.")
+  (let [;; Create an identifier for the graph.
+        gid (str (java.util.UUID/randomUUID))]
+    (hash-map
+     ;; Create a new, single EPGM graph, to which all nodes and edges belong.
+     :graphs (vector (hash-map :data (hash-map)
+                               :meta (hash-map :label gl)
+                               :id gid))
+     ;; Add the graph ID to all nodes and convert hash-maps to valid EPGM.
+     :nodes (eduction
+             (comp (map (partial add-graph-id gid))
+                   (map node-map-to-epgm))
+             vs)
+     ;; Add the graph ID to all edges and convert hash-maps to valid EPGM.
+     :edges (eduction
+             (comp (map (partial add-graph-id gid))
+                   (map node-map-to-epgm))
+             es))))
+
+;; Dispatch function, selects the graph backend, defaulting to Utils.
+(defn populate-graph
+  ""
+  ([vs es gl] (populate-graph-utils vs es gl))
+  ([vs es gl be]
+   ;; The backend can be either a keyword selecting one of the ingestor built-in
+   ;; backends (:native, :utils) or a function that does the job.
+   (if (clojure.test/function? be)
+     (apply be vs es gl)
+     (if (= be :native)
+       (populate-graph-native vs es gl)
+       (if (= be :utils)
+         (populate-graph-utils vs es gl)
+         (throw (new IllegalArgumentException
+                     (str "Unknown graph backend " be "."))))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Graph  output functions.  Those with  '-utils' suffix  employ the  deprecated
+;; stellar-utils methods to write to JSON and GDF.
+
+(defn write-graph-to-gdf-utils
   "Extract a graph  collection for the corresponding builder  object and write
   it to file in GDF format."
   [graph  ;; A StellarGraphBuffer object
@@ -351,10 +445,9 @@
       .toGraph
       .toCollection
       .write
-      (.gdf path))
-  )
+      (.gdf path)))
 
-(defn write-graph-to-json
+(defn write-graph-to-json-utils
   "Extract a graph  collection for the corresponding builder  object and write
   it to file in JSON (EPGM) format."
   [graph  ;; A StellarGraphBuffer object
@@ -364,29 +457,150 @@
       .toGraph
       .toCollection
       .write
-      (.json path))
-  )
+      (.json path)))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; With introduction of multi-source input the  schema is treated as a project
-;; file, from which  a project object is constructed. This  contains a list of
-;; the source files (full path) each with the corresponding subschema.
-(defn create-maps-from-project
-  [pro]
-  {:nodes
-   (fn []
-     (map #(assoc-in %1 [:stellar-count] (inc %2))
-          (apply concat
-                 (map #(create-node-maps (second %) (load-csv (first %))) pro))
-          (range)))
-   :links
-   (fn []
-     (map #(let [x (assoc-in %1 [:stellar-count] (inc %2))]
-             (if (nil? (get-in x [:props :__id]))
-               (assoc-in x [:props :__id] %2) x))
-          (apply concat
-                 (map #(create-link-maps (second %) (load-csv (first %))) pro))
-          (range)))})
+(defn write-graph-to-json-native
+  "
+  Write  to  JSON  the  EPGM  graph, built  using  stellar-ingest  native  graph
+  backend (see function populate-graph).
+  "
+  [graph ;; Graph object.
+   path] ;; Directory for EPGM output.
+  ;; TODO: factor out common code (see  commented code below function), wrap I/O
+  ;; exceptions with eithers and fmap over the individual output files.
+  (and
+   ;; Check is output dir exists or create it.
+   (let [wd (clojure.java.io/file path)]
+     (if (or (.isDirectory wd)
+             (.mkdirs (clojure.java.io/file path)))
+       true
+       (do (log/error (str "Error creating EPGM output directory " path))
+           false)))
+   ;; Write graphs.
+   (try
+     (with-open [file (clojure.java.io/writer (str path "/graphs.json"))]
+       (let [wf #(do (.write file (json/generate-string %)) (.newLine file))]
+         (log/info (str (new java.util.Date) " - Starting graph ID writing."))
+         (transduce (comp (utils/writing-tran wf)
+                          (utils/element-log-tran #(log/info %) 250000 "graph IDs"))
+                    (constantly nil) nil
+                    (:graphs graph))
+         (log/info (str (new java.util.Date) " - Completed graph ID writing."))
+         true))
+     (catch Exception e (log/error (str "Error writing EPGM graphs: "
+                                        (.getMessage e))) false))
+   ;; Write nodes.
+   (try
+     (with-open [file (clojure.java.io/writer (str path "/nodes.json"))]
+       (let [wf #(do (.write file (json/generate-string %)) (.newLine file))]
+         (log/info (str (new java.util.Date) " - Starting node ingestion."))
+         (transduce (comp (utils/writing-tran wf)
+                          (utils/element-log-tran #(log/info %) 250000 "nodes"))
+                    (constantly nil) nil
+                    (:nodes graph))
+         (log/info (str (new java.util.Date) " - Completed node ingestion."))
+         true))
+     (catch Exception e (log/error (str "Error writing EPGM nodes: "
+                                        (.getMessage e))) false))
+   ;; Write links.
+   (try
+     (with-open [file (clojure.java.io/writer (str path "/links.json"))]
+       (let [wf #(do (.write file (json/generate-string %)) (.newLine file))]
+         (log/info (str (new java.util.Date) " - Starting link ingestion."))
+         (transduce (comp (utils/writing-tran wf)
+                          (utils/element-log-tran #(log/info %) 250000 "links"))
+                    (constantly nil) nil
+                    (:edges graph))
+         (log/info (str (new java.util.Date) " - Completed link ingestion."))
+         true))
+     (catch Exception e (log/error (str "Error writing EPGM links: "
+                                        (.getMessage e))) false))))
+
+;; Dispatch function, that selects the  EPGM JSON output backend, defaulting the
+;; the Utils.
+;; TODO: the different graph construction backends should return different types
+;; and the output backend should be selected automatically based on them.
+(defn write-graph-to-json
+  ""
+  ([graph path] (write-graph-to-json-utils graph path))
+  ([graph path be]
+   ;; The backend can be either a keyword selecting one of the ingestor built-in
+   ;; backends (:native, :utils) or a function that does the job.
+   (if (clojure.test/function? be)
+     (apply be graph path)
+     (if (= be :native)
+       (write-graph-to-json-native graph path)
+       (if (= be :utils)
+         (write-graph-to-json-utils graph path)
+         (throw (new IllegalArgumentException
+                     (str "Unknown JSON output backend " be "."))))))))
+
+;; TODO: possible way of rewriting to avoid code duplication.
+;;
+;; (defn write-graph-to-json-native
+;;   [graph
+;;    path] ;; Directory for EPGM
+;;   (let [epgms [{:f "graphs.json" :l "graph IDs" :k :graphs}
+;;                {:f "nodes.json" :l "nodes" :k :nodes}
+;;                {:f "links.json" :l "links" :k :edges}]
+;;         ;; Common function to  write the EPGM JSON files,  using parameters from
+;;         ;; the 'epgms' map defined above.
+;;         ff (fn [f l k] ;; filename, name in logs, key in graph object
+;;              (try
+;;                (with-open [file (clojure.java.io/writer (str path "/" f))]
+;;                  (let [wf #(do (.write file (json/generate-string %)) (.newLine file))]
+;;                    (transduce (comp (utils/writing-tran wf)
+;;                                     (element-log-tran #(log/info %) 250000 l))
+;;                               (constantly nil) nil
+;;                               (k graph))
+;;                    true))
+;;                (catch Exception e (log/error (str "Error writing EPGM nodes: "
+;;                                                   (.getMessage e))))
+;;                (finally false)))]
+;;     ;; Create directory, map ff on epgms...
+;;     )
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Using the ingestor  project object, generate sequences  of maps, representing
+;; nodes and  links.  These are  the ingestor intermediate  representation.  The
+;; results are eductions, that encapsulate the actual sequence creation.
+
+;; Add an index to a node/link map (as value of :stellar-count). If the original
+;; ID is not saved as property (value of :__id) then add the index as ID too.
+(defn- add-idx [idx el]
+  (let [x (assoc-in el [:stellar-count] (inc idx))]
+    (if (nil? (get-in x [:props :__id]))
+      (assoc-in x [:props :__id] idx)
+      x)))
+
+;; Parse a CSV file and attach to each record the corresponding subschema.
+(defn- attach-schema-to-records [file scm]
+  (eduction (comp (dsrc/csv-data->maps-trans)
+                  (map #(hash-map :schema scm :record %)))
+            (dsrc/parse-csv-file-reducible file)))
+
+;; Create the intermediate node/link sequences as eductions.
+(defn- create-maps-from-project
+  [pro]   ;; Input ingestor project.
+  {:nodes ;; Eduction generating the ingestor's internal node maps.
+   (eduction (comp
+              ;; Filter out sources not contributing to node creation.
+              (filter #(not (empty? (-> (second %) :mapping :nodes))))
+              ;; Create a sequence  of records from all node  sources and attach
+              ;; to each the relevant subschema.
+              (mapcat #(attach-schema-to-records (first %) (second %)))
+              ;; Convert  the  records into internal ingestor map.
+              (mapcat #(apply-all-node-mappings (:schema %) (:record %)))
+              ;; Add to each node a global index, useful e.g. to track progress.
+              (map-indexed add-idx))
+             pro)
+   :links ;; Eduction generating the ingestor's internal link maps.
+   (eduction (comp
+              (filter #(not (empty? (-> (second %) :mapping :links))))
+              (mapcat #(attach-schema-to-records (first %) (second %)))
+              (mapcat #(apply-all-link-mappings (:schema %) (:record %)))
+              (map-indexed add-idx))
+             pro)})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Ingest data and  create a graph from a project  definition. The input project
@@ -402,7 +616,7 @@
           ns (cats/fmap :nodes maps)
           ls (cats/fmap :links maps)
           lab (cats/fmap (comp :label second first) pro)]
-      ((cats/lift-m populate-graph) ns ls lab)
+      ((cats/lift-m 3 populate-graph) ns ls lab)
       ;; maps
       )
     (catch Exception e (either/left (.getMessage e)))))
@@ -526,8 +740,8 @@
           glabel (nth args 2)
           graph (ingest scm-file {:label glabel})]
       (if (either/right? graph)
-        ;; Function write-graph-to-json  creates intermediate dirs  and consumes
-        ;; all I/O exceptions. It returns status as boolean.
+        ;; Function write-graph-to-json creates intermediate  dirs if needed and
+        ;; consumes all I/O exceptions. It returns status as boolean.
         (if (write-graph-to-json (deref graph) out-file)
           (println (str "Saved EPGM graph to " out-file))
           (do (println (str "I/O error saving graph to " out-file))
@@ -537,45 +751,40 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Scratch
 ;;
-;;
+;; Commands to watch Ingestor's memory consumption:
 ;; java -Xmx16g -cp ./target/uberjar/stellar-ingest-0.1.1-SNAPSHOT-standalone.jar stellar_ingest.schema /home/ubuntu/CSIRO/DATA/Stellar/Ingestor/livejournal/livejournal_short.json /tmp/lj lj
+;; java -Xmx16g -cp ./target/uberjar/stellar-ingest-0.1.1-SNAPSHOT-standalone.jar stellar_ingest.schema /home/amm00b/CSIRO/DATA/Stellar/Ingestor/livejournal/livejournal.json /tmp/lj lj
 ;; top -bH -p $(ps aux|grep "java -Xmx16g -cp"|grep -v grep|sed 's/\t/ /g;s/  */ /g'|cut -d" " -f2) 2>&1|tee mem.log
 ;; 
 (comment
 
-  (def scm-file "/home/amm00b/CSIRO/DATA/Stellar/Ingestor/livejournal/livejournal.json")
-  (def scm (load-schema scm-file))
-  (def scm (assoc scm :label "gtest"))
-  (def scm (assoc scm :schema-file scm-file))
-  (def scm (vtor/validate-schema scm))
-  ;; scm
+  ;; Load and validate schema. Turn it into a project object.
+  (do
+    ;; (def scm-file "/home/amm00b/CSIRO/DATA/Stellar/Ingestor/livejournal/livejournal.json")
+    ;; (def scm-file "/home/amm00b/CSIRO/DATA/Stellar/Ingestor/livejournal/livejournal_head.json")
+    (def scm-file "/home/amm00b/CSIRO/WORK/Dev/Stellar/stellar-ingest-dev/resources/examples/imdb_norm/imdb_norm_schema.json")
+    (def scm (load-schema scm-file))
+    (def scm (assoc scm :label "gtest"))
+    (def scm (assoc scm :schema-file scm-file))
+    (def scm (vtor/validate-schema scm))
+    (def pro (cats/bind scm schema-to-project)))
 
-  (def pro (cats/bind scm schema-to-project))
-  ;; pro
-
-  (def graph (ingest-project pro))
-  ;; graph
+  ;; Create maps with intermediate node/link representation.
+  (do
+    (def maps (cats/fmap create-maps-from-project pro))
+    (def nodes (cats/fmap :nodes maps))
+    (def links (cats/fmap :links maps))
+    (def lab (cats/fmap (comp :label second first) pro)))
   
-  (def maps (create-maps-from-project (deref pro)))
-  ;; maps
-    
-  ;; Lazily write out the maps and time the process.
-  (time (with-open [w (clojure.java.io/writer  "/tmp/nodes.edn")]
-          (doseq [n ((:nodes maps))]
-            (.write w (str n "\n")))))
+  ;; Build a graph with the default native backend, i.e.  create EPGM maps.
+  (def graph ((cats/lift-m 3 populate-graph) nodes links lab))
+
+  ;; Write EPGM graph to directory, creating it if needed.
+  (time (write-graph-to-json (deref graph) "/tmp/mygraph"))
+
+  ;; Deprecated: using the Utils backend.
+  (def graph ((cats/lift-m 4 populate-graph) nodes links lab (either/right :utils)))
   
-  (time (with-open [w (clojure.java.io/writer  "/tmp/links.edn")]
-          (doseq [l ((:links maps))]
-            (.write w (str l "\n")))))
-
-  ;; Count nodes and links in maps and time the process.
-  (time (count ((:nodes maps)))) 
-  (time (count ((:links maps))))
-
-  ;; Populate the utils graph and write it out.
-  (def graph (populate-graph (:nodes maps) (:links maps) "testg"))
-
-  ;; graph.toGraph().toCollection().write().json("out.epgm");
   (-> (deref graph)
       .toGraph
       .toCollection


### PR DESCRIPTION
Completed native EPGM writer, both with and without replacement of IDs with UUIDs. This is the base building block of writing large graphs to HDFS. The ingestion backend now support all iterable objects, e.g. database queries.

Example performance:
* 5 million nodes: 70 seconds
* 70 million links: 700 seconds

Memory occupation: constant 1.5 GB for streaming (keep original IDs) and 6GB for in memory (UUID replacement).
